### PR TITLE
Fix Directors and Creators parsing due to imdb changes

### DIFF
--- a/Addons/scraper.IMDB.Data/My Project/AssemblyInfo.vb
+++ b/Addons/scraper.IMDB.Data/My Project/AssemblyInfo.vb
@@ -31,5 +31,5 @@ Imports System.Runtime.InteropServices
 ' by using the '*' as shown below:
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
-<Assembly: AssemblyVersion("1.11.1.7")>
-<Assembly: AssemblyFileVersion("1.11.1.7")>
+<Assembly: AssemblyVersion("1.11.1.8")>
+<Assembly: AssemblyFileVersion("1.11.1.8")>

--- a/Addons/scraper.IMDB.Data/Scraper/clsIMDBJson.vb
+++ b/Addons/scraper.IMDB.Data/Scraper/clsIMDBJson.vb
@@ -38,6 +38,7 @@ Public Class MainColumnData
     Public Property Genres As Genres 'List of genres e.g. "Action", "Comedy", "Crime"
     Public Property Certificate As MainColumnDataCertificate 'Rating information (R), (TV-MA)
     Public Property CompanyCreditCategories As List(Of CompanyCreditCategoryWithCompanyCredits) 'All companies involved ordered by company catergory e.g. "Castle Rock Entertainment" when Category is "production"
+    Public Property principalCreditsV2 As List(Of PrincipalCreditsForGrouping)
 End Class
 
 Public Class ContentData
@@ -275,11 +276,11 @@ Public Class PrincipalCreditsForCategory
 End Class
 
 Public Class Crew
-    Public Property Name As Name
+    Public Property Name As NameWithPrimaryImage
     Public Property __typename As String
 End Class
 
-Public Class Name
+Public Class NameWithPrimaryImage
     Public Property Id As String
     Public Property NameText As NameText
     Public Property PrimaryImage As PrimaryImage
@@ -395,4 +396,26 @@ End Class
 
 Public Class DisplayableTitleCompanyCreditProperty
     Public Property Value As Markdown
+End Class
+
+Public Class PrincipalCreditsForGrouping
+    Public Property totalCredits As Integer
+    Public Property grouping As CreditGrouping
+    Public Property credits As List(Of CreditV2)
+End Class
+
+Public Class CreditGrouping
+    Public Property Text As String 'E.g. Stars, Creator
+    Public Property groupingId As String
+    Public Property __typename As String
+End Class
+
+Public Class CreditV2
+    Public Property name As NameWithouthPrimaryImage
+End Class
+
+Public Class NameWithouthPrimaryImage
+    Public Property Id As String
+    Public Property NameText As NameText
+    Public Property __typename As String
 End Class

--- a/Addons/scraper.IMDB.Data/Scraper/clsScrapeIMDB.vb
+++ b/Addons/scraper.IMDB.Data/Scraper/clsScrapeIMDB.vb
@@ -1064,17 +1064,21 @@ Public Class Scraper
     End Function
 
     Private Function ParseCreators(ByRef json_data As IMDBJson) As List(Of String)
-        Dim Creators As List(Of CreatorPrincipalCreditsForCategory)
+        Dim PrincipalCredit As List(Of PrincipalCreditsForGrouping)
         Dim nCreators As New List(Of String)
 
-        'Creators for series is only stored in CreatorsPageTitle, it's not present in MainColumnData.Categories
-        If json_data.props.PageProps.MainColumnData.CreatorsPageTitle IsNot Nothing Then
-            Creators = json_data.props.PageProps.MainColumnData.CreatorsPageTitle
+        'Creators for series is only stored in principalCreditsV2 grouped as "Creator", it's not present in MainColumnData.Categories
+        If json_data.props.PageProps.MainColumnData.principalCreditsV2 IsNot Nothing Then
+            PrincipalCredit = json_data.props.PageProps.MainColumnData.principalCreditsV2
 
-            For Each nCreator In Creators
-                For Each nCredit In nCreator.Credits
-                    nCreators.Add(nCredit.Name.NameText.Text)
-                Next
+            For Each nCreator In PrincipalCredit
+                If nCreator.grouping IsNot Nothing AndAlso nCreator.credits IsNot Nothing Then
+                    If String.Equals(nCreator.grouping.Text, "creator", StringComparison.OrdinalIgnoreCase) Then
+                        For Each nCredit In nCreator.credits
+                            nCreators.Add(nCredit.name.NameText.Text)
+                        Next
+                    End If
+                End If
             Next
 
             If nCreators IsNot Nothing Then
@@ -1111,18 +1115,24 @@ Public Class Scraper
     End Function
 
     Private Function ParseDirectors(ByRef json_data As IMDBJson) As List(Of String)
-        If json_data.props.PageProps.MainColumnData.DirectorsPageTitle IsNot Nothing Then
-            Dim DirectorCrewList As List(Of PrincipalCreditsForCategory)
+        If json_data.props.PageProps.MainColumnData.Categories IsNot Nothing Then
             Dim nDirectors As New List(Of String)
+            Dim CreditCategoriesList As List(Of Category) = json_data.props.PageProps.MainColumnData.Categories
 
-            DirectorCrewList = json_data.props.PageProps.MainColumnData.DirectorsPageTitle
+            If CreditCategoriesList IsNot Nothing Then
+                For Each CreditCategory In CreditCategoriesList
+                    If CreditCategory.Id IsNot Nothing AndAlso CreditCategory.Section IsNot Nothing Then
+                        If String.Equals(CreditCategory.Name, "director", StringComparison.OrdinalIgnoreCase) Then
+                            'Loop all creditconnection edges wich contains director members
 
-            If DirectorCrewList IsNot Nothing Then
-                For Each nDirector In DirectorCrewList
-                    nDirectors.Add(nDirector.Credits(0).Name.NameText.Text)
+                            For Each json_section_item As CategoryItem In CreditCategory.Section.Items
+                                nDirectors.Add(json_section_item.RowTitle)
+                            Next
+
+                            Return nDirectors
+                        End If
+                    End If
                 Next
-
-                Return nDirectors
             End If
         End If
 


### PR DESCRIPTION
Fixes https://github.com/nagten/Ember-MM-Newscraper/issues/31

IMDB removed CreatorsPageTitle and DirectorsPageTitle from the the json data, the data is now accessible via principalCreditsV2 and Directors information via categories.